### PR TITLE
Adding patching of udf when it already exists

### DIFF
--- a/occupancy-quickstart/src/actions/descriptionsExtensions.cs
+++ b/occupancy-quickstart/src/actions/descriptionsExtensions.cs
@@ -71,6 +71,15 @@ namespace Microsoft.Azure.DigitalTwins.Samples
                 ParentSpaceId = parentId != Guid.Empty ? parentId.ToString() : "",
             };
 
+        public static Models.UserDefinedFunction ToUserDefinedFunction(this UserDefinedFunctionDescription description, string Id, Guid spaceId, IEnumerable<string> matcherIds)
+            => new Models.UserDefinedFunction()
+            {
+                Id = Id,
+                Name = description.name,
+                SpaceId = spaceId.ToString(),
+                Matchers = matcherIds,
+            };
+
         public static Models.UserDefinedFunctionCreate ToUserDefinedFunctionCreate(this UserDefinedFunctionDescription description, Guid spaceId, IEnumerable<string> matcherIds)
             => new Models.UserDefinedFunctionCreate()
             {

--- a/occupancy-quickstart/src/actions/provisionSample.cs
+++ b/occupancy-quickstart/src/actions/provisionSample.cs
@@ -227,11 +227,13 @@ namespace Microsoft.Azure.DigitalTwins.Samples
                     }
                     else
                     {
-                        await Api.CreateUserDefinedFunction(
+                        await CreateOrPatchUserDefinedFunction(
                             httpClient,
                             logger,
-                            description.ToUserDefinedFunctionCreate(spaceId, new [] { matcher.Id }),
-                            js);
+                            description,
+                            js,
+                            spaceId,
+                            new [] { matcher.Id });
                     }
                 }
             }
@@ -255,6 +257,34 @@ namespace Microsoft.Azure.DigitalTwins.Samples
             return existingSpace?.Id != null
                 ? Guid.Parse(existingSpace.Id)
                 : await Api.CreateSpace(httpClient, logger, description.ToSpaceCreate(parentId));
+        }
+
+        private static async Task CreateOrPatchUserDefinedFunction(
+            HttpClient httpClient,
+            ILogger logger,
+            UserDefinedFunctionDescription description,
+            string js,
+            Guid spaceId,
+            IEnumerable<string> matcherIds)
+        {
+            var userDefinedFunction = await Api.FindUserDefinedFunction(httpClient, logger, description.name, spaceId);
+
+            if (userDefinedFunction != null)
+            {
+                await Api.UpdateUserDefinedFunction(
+                    httpClient,
+                    logger,
+                    description.ToUserDefinedFunction(userDefinedFunction.Id, spaceId, matcherIds),
+                    js);
+            }
+            else
+            {
+                await Api.CreateUserDefinedFunction(
+                    httpClient,
+                    logger,
+                    description.ToUserDefinedFunctionCreate(spaceId, matcherIds),
+                    js);
+            }
         }
     }
 }

--- a/occupancy-quickstart/src/api/update.cs
+++ b/occupancy-quickstart/src/api/update.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.DigitalTwins.Samples
+{
+    public partial class Api
+    {
+        public static async Task UpdateUserDefinedFunction(
+            HttpClient httpClient,
+            ILogger logger,
+            Models.UserDefinedFunction userDefinedFunction,
+            string js)
+        {
+            logger.LogInformation($"Updating UserDefinedFunction with Metadata: {JsonConvert.SerializeObject(userDefinedFunction, Formatting.Indented)}");
+            var displayContent = js.Length > 100 ? js.Substring(0, 100) + "..." : js;
+            logger.LogInformation($"Updating UserDefinedFunction with Content: {displayContent}");
+
+            var metadataContent = new StringContent(JsonConvert.SerializeObject(userDefinedFunction), Encoding.UTF8, "application/json");
+            metadataContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+
+            var multipartContent = new MultipartFormDataContent("userDefinedFunctionBoundary");
+            multipartContent.Add(metadataContent, "metadata");
+            multipartContent.Add(new StringContent(js), "contents");
+
+            await httpClient.PatchAsync($"userdefinedfunctions/{userDefinedFunction.Id}", multipartContent);
+        }
+    }
+}

--- a/occupancy-quickstart/src/models/userDefinedFunction.cs
+++ b/occupancy-quickstart/src/models/userDefinedFunction.cs
@@ -4,7 +4,9 @@ namespace Microsoft.Azure.DigitalTwins.Samples.Models
 {
     public class UserDefinedFunction
     {
-        public string Name { get; set; }
         public string Id { get; set; }
+        public IEnumerable<string> Matchers { get; set; }
+        public string Name { get; set; }
+        public string SpaceId { get; set; }
     }
 }

--- a/occupancy-quickstart/src/models/userDefinedFunctionCreate.cs
+++ b/occupancy-quickstart/src/models/userDefinedFunctionCreate.cs
@@ -4,8 +4,8 @@ namespace Microsoft.Azure.DigitalTwins.Samples.Models
 {
     public class UserDefinedFunctionCreate
     {
+        public IEnumerable<string> Matchers { get; set; }
         public string Name { get; set; }
         public string SpaceId { get; set; }
-        public IEnumerable<string> Matchers { get; set; }
     }
 }

--- a/occupancy-quickstart/tests/fakeDigitalTwinsHttpClient.cs
+++ b/occupancy-quickstart/tests/fakeDigitalTwinsHttpClient.cs
@@ -37,10 +37,12 @@ namespace Microsoft.Azure.DigitalTwins.Samples.Tests
         public static (HttpClient, FakeHttpHandler) CreateWithSpace(
             IEnumerable<Guid> postResponseGuids,
             IEnumerable<HttpResponseMessage> getResponses = null,
+            IEnumerable<HttpResponseMessage> patchResponses = null,
             Models.Space space = null)
         {
             postResponseGuids = postResponseGuids ?? Array.Empty<Guid>();
             getResponses = getResponses ?? Array.Empty<HttpResponseMessage>();
+            patchResponses = patchResponses ?? Array.Empty<HttpResponseMessage>();
             space = space ?? Space;
 
             var getRootSpaceResponse = new HttpResponseMessage()
@@ -55,7 +57,8 @@ namespace Microsoft.Azure.DigitalTwins.Samples.Tests
                 postResponses: CreateGuidResponses(postResponseGuids),
                 getResponses: new [] { getRootSpaceResponse }
                     .Concat(getResponses)
-                    .Concat(getSensorsForResultsResponse));
+                    .Concat(getSensorsForResultsResponse),
+                patchResponses: patchResponses);
         }
 
         // Creates an httpClient that will respond with a space and device

--- a/occupancy-quickstart/tests/fakeHttpHandler.cs
+++ b/occupancy-quickstart/tests/fakeHttpHandler.cs
@@ -16,12 +16,14 @@ namespace Microsoft.Azure.DigitalTwins.Samples
     {
         public static (HttpClient, FakeHttpHandler) CreateHttpClient(
             IEnumerable<HttpResponseMessage> postResponses = null,
-            IEnumerable<HttpResponseMessage> getResponses = null)
+            IEnumerable<HttpResponseMessage> getResponses = null,
+            IEnumerable<HttpResponseMessage> patchResponses = null)
         {
             var httpHandler = new FakeHttpHandler()
             {
                 PostResponses = postResponses,
                 GetResponses = getResponses,
+                PatchResponses = patchResponses,
             };
             return (
                 new HttpClient(httpHandler)
@@ -36,10 +38,12 @@ namespace Microsoft.Azure.DigitalTwins.Samples
         {
             requests[HttpMethod.Post] = new Dictionary<string, List<HttpRequestMessage>>();
             requests[HttpMethod.Get] = new Dictionary<string, List<HttpRequestMessage>>();
+            requests[HttpMethod.Patch] = new Dictionary<string, List<HttpRequestMessage>>();
         }
 
-        public IReadOnlyDictionary<string, List<HttpRequestMessage>> PostRequests => requests[HttpMethod.Post];
+        public IReadOnlyDictionary<string, List<HttpRequestMessage>> PatchRequests => requests[HttpMethod.Patch];
         public IReadOnlyDictionary<string, List<HttpRequestMessage>> GetRequests => requests[HttpMethod.Get];
+        public IReadOnlyDictionary<string, List<HttpRequestMessage>> PostRequests => requests[HttpMethod.Post];
         private Dictionary<HttpMethod, Dictionary<string, List<HttpRequestMessage>>> requests = new Dictionary<HttpMethod, Dictionary<string, List<HttpRequestMessage>>>();
 
         public IEnumerable<HttpResponseMessage> PostResponses { get; set; }
@@ -47,6 +51,9 @@ namespace Microsoft.Azure.DigitalTwins.Samples
 
         public IEnumerable<HttpResponseMessage> GetResponses { get; set; }
         private IEnumerator<HttpResponseMessage> enumerateGetResponses;
+
+        public IEnumerable<HttpResponseMessage> PatchResponses { get; set; }
+        private IEnumerator<HttpResponseMessage> enumeratePatchResponses;
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -72,6 +79,12 @@ namespace Microsoft.Azure.DigitalTwins.Samples
                 if (enumerateGetResponses == null)
                     enumerateGetResponses = GetResponses.GetEnumerator();
                 return enumerateGetResponses;
+            }
+            else if (request.Method == HttpMethod.Patch)
+            {
+                if (enumeratePatchResponses == null)
+                    enumeratePatchResponses = PatchResponses.GetEnumerator();
+                return enumeratePatchResponses;
             }
             else if (request.Method == HttpMethod.Post)
             {

--- a/occupancy-quickstart/tests/responses.cs
+++ b/occupancy-quickstart/tests/responses.cs
@@ -9,5 +9,10 @@ namespace Microsoft.Azure.DigitalTwins.Samples.Tests
         {
             StatusCode = HttpStatusCode.NotFound,
         };
+
+        public static HttpResponseMessage OK = new HttpResponseMessage()
+        {
+            StatusCode = HttpStatusCode.OK,
+        };
     }
 }


### PR DESCRIPTION
## Purpose
* When the sampleProvision.yaml has a udf that, under the same parent, has the same name as a preexisting one, it will now do a patch instead of a create.
* The only way to see UDFs in action is to make changes and re-upload.  We have already ran into issues trying to update and so we think this will be common enough that people want to update without having to create new matchers and functions (also it will save us time in development)

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] New sample or new feature within a sample
[ ] Code style update (formatting, naming)
[ ] Refactoring (no functional changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Tested by
* Added a test and ran tests
* Ran manually - both the patch case and the create case