### PR TITLE
Make GetAvailableAndFreshSpaces clearer on failure and if run before device-connectivity is run

### DIFF
--- a/occupancy-quickstart/src/actions/getAvailableAndFreshSpaces.cs
+++ b/occupancy-quickstart/src/actions/getAvailableAndFreshSpaces.cs
@@ -21,13 +21,21 @@ namespace Microsoft.Azure.DigitalTwins.Samples
             var maxGets = 30;
             for (var curGets = 0; curGets < maxGets; ++curGets)
             {
-                var spaces = await GetManagementItemsAsync<Models.Space>(httpClient, "spaces", "includes=values");
+                var (spaces, response) = await GetManagementItemsAsync<Models.Space>(httpClient, "spaces", "includes=values");
+                if (spaces == null)
+                {
+                    var content = await response.Content?.ReadAsStringAsync();
+                    Console.WriteLine($"ERROR: GET spaces?includes=values failed with: {(int)response.StatusCode}, {response.StatusCode} {content}");
+                    break;
+                }
+
                 var availableAndFreshSpaces = spaces.Where(s => s.Values != null && s.Values.Any(v => v.Type == "AvailableAndFresh"));
                 if (!availableAndFreshSpaces.Any())
                 {
                     Console.WriteLine("ERROR: Unable to find a space with value type 'AvailableAndFresh'");
                     break;
                 }
+
                 var availableAndFreshDisplay = availableAndFreshSpaces
                     .Select(s => GetDisplayValues(s))
                     .Aggregate((acc, cur) => acc + "\n" + cur);
@@ -36,7 +44,7 @@ namespace Microsoft.Azure.DigitalTwins.Samples
             }
         }
 
-        private static async Task<IEnumerable<T>> GetManagementItemsAsync<T>(
+        private static async Task<(IEnumerable<T>, HttpResponseMessage)> GetManagementItemsAsync<T>(
             HttpClient httpClient,
             string queryItem,
             string queryParams)
@@ -46,10 +54,10 @@ namespace Microsoft.Azure.DigitalTwins.Samples
             {
                 var content = await response.Content.ReadAsStringAsync();
                 var objects = JsonConvert.DeserializeObject<IEnumerable<T>>(content);
-                return objects;
+                return (objects, response);
             }
 
-            return null;
+            return (null, response);
         }
 
         private static string GetDisplayValues(Models.Space space)

--- a/occupancy-quickstart/src/actions/getAvailableAndFreshSpaces.cs
+++ b/occupancy-quickstart/src/actions/getAvailableAndFreshSpaces.cs
@@ -30,16 +30,18 @@ namespace Microsoft.Azure.DigitalTwins.Samples
                 }
 
                 var availableAndFreshSpaces = spaces.Where(s => s.Values != null && s.Values.Any(v => v.Type == "AvailableAndFresh"));
-                if (!availableAndFreshSpaces.Any())
+                if (availableAndFreshSpaces.Any())
                 {
-                    Console.WriteLine("ERROR: Unable to find a space with value type 'AvailableAndFresh'");
-                    break;
+                    var availableAndFreshDisplay = availableAndFreshSpaces
+                        .Select(s => GetDisplayValues(s))
+                        .Aggregate((acc, cur) => acc + "\n" + cur);
+                    Console.WriteLine($"{availableAndFreshDisplay}");
+                }
+                else
+                {
+                    Console.WriteLine("Unable to find a space with value type 'AvailableAndFresh'");
                 }
 
-                var availableAndFreshDisplay = availableAndFreshSpaces
-                    .Select(s => GetDisplayValues(s))
-                    .Aggregate((acc, cur) => acc + "\n" + cur);
-                Console.WriteLine($"{availableAndFreshDisplay}");
                 await Task.Delay(TimeSpan.FromSeconds(4));
             }
         }

--- a/occupancy-quickstart/src/loggingHttpHandler.cs
+++ b/occupancy-quickstart/src/loggingHttpHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.DigitalTwins.Samples
                 ? content
                 : content.Substring(0, maxContentLength - 3) + "...";
             var contentDisplay = contentMaxLength == null ? "" : $", {contentMaxLength}";
-            logger.LogTrace($"Response Status: {(int)response.StatusCode}, {response.StatusCode}{contentDisplay}");
+            logger.LogTrace($"Response Status: {(int)response.StatusCode}, {response.StatusCode} {contentDisplay}");
 
             // Enable to get more details:
             // logger.LogTrace($"Full Response: {Serialize(response)}");


### PR DESCRIPTION
## Purpose

### Make GetAvailableAndFreshSpaces Give More Info on Failure
Currently when the GET request in GetAvailableAndFreshSpaces fails no info is published to console as to why it failed (because it uses a SilentLogger so as to not generate a bunch of noise during success full cases (since it polls for results every few seconds). This change will make it log and break from the loop if the GET spaces results in a failure.
![image](https://user-images.githubusercontent.com/16008355/47468929-0488eb80-d7b3-11e8-984a-86eec4b66b80.png)


### Make GetAvailableAndFreshSpaces More Patient
Also changed GetAvailableAndFreshSpaces to keep trying when the GET call succeeds but the space does not yet have the properties set (currently it stops in this case).  This fixes the case where you started both the GetAvailableAndFreshSpaces and the sending the device-connectivity data at the same time (since it takes a few seconds for the udfs to process the sensor info).
For this case this will now look like:
![image](https://user-images.githubusercontent.com/16008355/47468870-abb95300-d7b2-11e8-9e85-6b228734ff53.png)




## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] New sample or new feature within a sample
[ ] Code style update (formatting, naming)
[ ] Refactoring (no functional changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Test By

<!-- For code changes, please provide details with how you validated the change. For non trivial changes please add and/or augment unit tests, if possible, so that we can keep the code as easy to maintain as possible. 
At a minimum:
1. run relevent tests using: dotnet test <folder>.tests 
2. run the relevent samples using:
  * cd <folder> or cd <folder>\src
  * dotnet run
-->

Please describe how you tested

## Other Information
dotnet run GetAvailableAndFreshSpaces in both success and failure cases (failure case shown in image above)

dotnet run GetAvailableAndFreshSpaces before device-connectivity was started up and then see how it changes once the device-connectivity is run (results in the image above)