### PR TITLE
Fix occupancy appSettings filename for linux (case-sensitive)

### DIFF
--- a/occupancy-quickstart/src/appSettings.cs
+++ b/occupancy-quickstart/src/appSettings.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Azure.DigitalTwins.Samples
         {
             var appSettings = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json")
-                .AddJsonFile("appsettings.dev.json", optional: true)
+                .AddJsonFile("appSettings.json")
+                .AddJsonFile("appSettings.dev.json", optional: true)
                 .Build()
                 .Get<AppSettings>();
 

--- a/occupancy-quickstart/src/occupancyQuickstart.csproj
+++ b/occupancy-quickstart/src/occupancyQuickstart.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="YamlDotNet" Version="5.0.1" />
-    <Content Include="appsettings.json">
+    <Content Include="appSettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
## Purpose

There is a problem with case-sensitive on linux. appSettings.json file mismatch the configuration.
Change variable name on 2 files:
- appSettings.cs
- occupancyQuickstart.csproj

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] New sample or new feature within a sample
[ ] Code style update (formatting, naming)
[ ] Refactoring (no functional changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Test By
Test on linux: all passed.
Run on linux: all works.

